### PR TITLE
Add config loader from PrairieGrader

### DIFF
--- a/fixtures/config/test.yaml
+++ b/fixtures/config/test.yaml
@@ -1,0 +1,8 @@
+parent: testbase
+properties:
+  testBoolean:
+    default: false
+  testNumber:
+    default: 456
+  testString:
+    default: 'goodbye'

--- a/fixtures/config/testbase.yaml
+++ b/fixtures/config/testbase.yaml
@@ -1,0 +1,10 @@
+properties:
+  testBoolean:
+    default: true
+    envVar: TEST_BOOLEAN
+  testNumber:
+    default: 123
+    envVar: TEST_NUMBER
+  testString:
+    default: 'hello'
+    envVar: TEST_STRING

--- a/index.js
+++ b/index.js
@@ -2,3 +2,4 @@ module.exports.sqlDb = require('./lib/sql-db');
 module.exports.sqlLoader = require('./lib/sql-loader');
 module.exports.error = require('./lib/error');
 module.exports.util = require('./lib/util');
+module.exports.config = require('./lib/config');

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,110 @@
+const ERR = require('async-stacktrace');
+const async = require('async');
+const fs = require('fs-extra');
+const path = require('path');
+const yaml = require('js-yaml');
+const _ = require('lodash');
+
+/**
+ * Module to load configuration from a config file and environment variables.
+ */
+
+/**
+ * Recursively loads and applies config files.
+ *
+ * @param  {String}   configDir   The directory containing config files
+ * @param  {String}   environment The name of the environment to load config for
+ * @param  {Function} callback    Receives an error or the merged config object
+ */
+module.exports.loadConfigForEnvironment = function (configDir, environment, callback) {
+    let configDescription, builtConfig = {};
+    let inheritedConfigs = [];
+    async.series([
+        (callback) => {
+            // Load configs, following the inheritance chain
+            let parent = environment;
+            async.whilst(
+                () => parent != null,
+                (callback) => {
+                    fs.readFile(path.join(configDir, `${parent}.yaml`), 'utf-8', (err, data) => {
+                        if (ERR(err, callback)) return;
+                        configDescription = yaml.safeLoad(data);
+                        inheritedConfigs.push(configDescription);
+                        parent = configDescription.parent || null;
+                        callback(null);
+                    });
+                },
+                (err) => {
+                    if (ERR(err, callback)) return;
+                    callback(null);
+                }
+            );
+        },
+        (callback) => {
+            // Merge the config descriptions, starting at the base and applying
+            // successively more specific configs
+            const mergedConfig = {};
+            for (const desc of inheritedConfigs.reverse()) {
+                _.merge(mergedConfig, desc.properties);
+            }
+            configDescription = mergedConfig;
+            callback(null);
+        },
+        (callback) => {
+            // Loop over the description of the config and construct a config
+            // object from default values and env var overrides
+            for (const itemKey in configDescription) {
+                const configItem = configDescription[itemKey];
+                if (configItem.default !== undefined) {
+                    builtConfig[itemKey] = configItem.default;
+                } else {
+                    callback(new Error(`${itemKey} is missing a default for environment ${environment}`));
+                    return;
+                }
+                // Override from env var
+                if (configItem.envVar !== undefined && process.env[configItem.envVar] !== undefined) {
+                    const envValue = process.env[configItem.envVar];
+                    if (typeof configItem.default === 'number') {
+                        try {
+                            builtConfig[itemKey] = Number.parseFloat(envValue);
+                        } catch (e) {
+                            callback(new Error(`Unable to parse ${configItem.envVar}=${envValue} as a number`));
+                            return;
+                        }
+                    } else if (typeof configItem.default === 'boolean') {
+                        if (envValue === 'true' || envValue === 'True' || envValue === 1) {
+                            builtConfig[itemKey] = true;
+                        } else if (envValue === 'false' || envValue === 'False' || envValue === 0) {
+                            builtConfig[itemKey] = false;
+                        } else {
+                            callback(new Error(`Unable to parse ${configItem.envVar}=${envValue} as a boolean`));
+                            return;
+                        }
+                    } else {
+                        builtConfig[itemKey] = envValue;
+                    }
+                }
+            }
+            callback(null);
+        },
+    ], (err) => {
+        if (ERR(err, callback)) return;
+        callback(null, builtConfig);
+    });
+};
+
+/**
+ * Loads a config from the specified directory, automatically selecting an
+ * environment if needed.
+ *
+ * @param  {[type]}   configDir    The directory containing config files
+ * @param  {Object}   options      Any options
+ * @param  {Function} callback     Callback to receive either an error of the loaded config
+ */
+module.exports.loadConfig = function(configDir, options = {}, callback) {
+    const env = options.env || process.env.NODE_ENV || 'development';
+    module.exports.loadConfigForEnvironment(configDir, env, (err, loadedConfig) => {
+        if (ERR(err, callback)) return;
+        callback(null, loadedConfig);
+    });
+};

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -1,0 +1,97 @@
+/* eslint-env jest */
+const path = require('path');
+const config = require('./config');
+
+describe('config', () => {
+    const configDir = path.resolve(__dirname, '..', 'fixtures', 'config');
+
+    it('loads defaults from config', (done) => {
+        config.loadConfigForEnvironment(configDir, 'testbase', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testBoolean).toBe(true);
+            expect(config.testNumber).toBe(123);
+            expect(config.testString).toBe('hello');
+            done();
+        });
+    });
+
+    it('overrides boolean from environment variable', (done) => {
+        process.env['TEST_BOOLEAN'] = 'false';
+        config.loadConfigForEnvironment(configDir, 'testbase', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testBoolean).toBe(false);
+            delete process.env['TEST_BOOLEAN'];
+            done();
+        });
+    });
+
+    it('overrides number from environment variable', (done) => {
+        process.env['TEST_NUMBER'] = '321';
+        config.loadConfigForEnvironment(configDir, 'testbase', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testNumber).toBe(321);
+            delete process.env['TEST_NUMBER'];
+            done();
+        });
+    });
+
+    it('overrides string from environment variable', (done) => {
+        process.env['TEST_STRING'] = 'olleh';
+        config.loadConfigForEnvironment(configDir, 'testbase', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testString).toBe('olleh');
+            delete process.env['TEST_STRING'];
+            done();
+        });
+    });
+
+    it('inheritance: loads from config with a parent', (done) => {
+        config.loadConfigForEnvironment(configDir, 'test', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testBoolean).toBe(false);
+            expect(config.testNumber).toBe(456);
+            expect(config.testString).toBe('goodbye');
+            done();
+        });
+    });
+
+    it('inheritance: overrides boolean from environment variable (true)', (done) =>{
+        process.env['TEST_BOOLEAN'] = 'true';
+        config.loadConfigForEnvironment(configDir, 'test', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testBoolean).toBe(true);
+            delete process.env['TEST_BOOLEAN'];
+            done();
+        });
+    });
+
+    it('inheritance: overrides boolean from environment variable (false)', (done) => {
+        process.env['TEST_BOOLEAN'] = 'false';
+        config.loadConfigForEnvironment(configDir, 'test', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testBoolean).toBe(false);
+            delete process.env['TEST_BOOLEAN'];
+            done();
+        });
+    });
+
+    it('inheritance: overrides number from environment variable', (done) => {
+        process.env['TEST_NUMBER'] = '321';
+        config.loadConfigForEnvironment(configDir, 'test', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testNumber).toBe(321);
+            delete process.env['TEST_NUMBER'];
+            done();
+        });
+    });
+
+    it('inheritance: overrides string from environment variable', (done) =>{
+        process.env['TEST_STRING'] = 'olleh';
+        config.loadConfigForEnvironment(configDir, 'test', (err, config) => {
+            expect(err).toBe(null);
+            expect(config.testString).toBe('olleh');
+            delete process.env['TEST_STRING'];
+            done();
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@prairielearn/prairielib",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -423,7 +423,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -510,7 +509,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
       "requires": {
         "lodash": "^4.14.0"
       }
@@ -1619,8 +1617,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -1919,6 +1916,16 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -2551,8 +2558,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growly": {
       "version": "1.3.0",
@@ -3613,7 +3619,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3704,6 +3709,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -5530,8 +5543,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.14.1",
@@ -6190,6 +6202,11 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
   "author": "",
   "license": "AGPL-3.0",
   "dependencies": {
+    "async": "^2.6.0",
     "async-stacktrace": "0.0.2",
     "debug": "^3.1.0",
+    "fs-extra": "^6.0.1",
+    "js-yaml": "^3.11.0",
     "lodash": "^4.17.5",
     "pg": "^7.4.1"
   },


### PR DESCRIPTION
I want to use the load-from-env-var feature in PL, so I decided to extract the whole thing into PLib. I simplified and changed the interface a bit: you have to directly pass a directory to load from, and the config is returned via a callback and not exported directly by the module.