### PR TITLE
Add Promise-based variants of all database functions

### DIFF
--- a/lib/sql-db.js
+++ b/lib/sql-db.js
@@ -35,15 +35,15 @@ function paramsToArray(sql, params, callback) {
     if (!_.isString(sql)) return callback(new Error('SQL must be a string'));
     if (_.isArray(params)) return callback(null, sql, params);
     if (!_.isObjectLike(params)) return callback(new Error('params must be array or object'));
-    var re = /\$([-_a-zA-Z0-9]+)/;
-    var result;
-    var processedSql = '';
-    var remainingSql = sql;
-    var nParams = 0;
-    var map = {};
-    var paramsArray = [];
+    const re = /\$([-_a-zA-Z0-9]+)/;
+    let result;
+    let processedSql = '';
+    let remainingSql = sql;
+    let nParams = 0;
+    const map = {};
+    let paramsArray = [];
     while ((result = re.exec(remainingSql)) !== null) {
-        var v = result[1];
+        const v = result[1];
         if (!_(map).has(v)) {
             if (!_(params).has(v)) return callback(new Error('Missing parameter: ' + v));
             if (_.isArray(params[v])) {
@@ -68,12 +68,12 @@ function paramsToArray(sql, params, callback) {
 let pool = null;
 
 /** @typedef {Object | Array} Params */
-/** @typedef {(result: import("pg")) => void} ResultsCallback */
+/** @typedef {(error: Error | null, result: import("pg").QueryResult) => void} ResultsCallback */
 
 /**
  * @param { import("pg").PoolConfig } pgConfig - The config object for Postgres
  * @param {(error: Error, client: import("pg").PoolClient) => void} idleErrorHandler - A handler for async errors
- * @param {(error: Error?) => void} callback - Callback once the connection is initialized
+ * @param {(error: Error | null) => void} callback - Callback once the connection is initialized
  */
 module.exports.init = function(pgConfig, idleErrorHandler, callback) {
     try {
@@ -114,6 +114,9 @@ module.exports.init = function(pgConfig, idleErrorHandler, callback) {
     tryConnect();
 }
 
+/**
+ * @param {(error: Error | null) => void} callback
+ */
 module.exports.close = function(callback) {
     if (!pool) {
         return callback(null);
@@ -125,6 +128,9 @@ module.exports.close = function(callback) {
     });
 }
 
+/**
+ * @param {(error: Error | null, client: import("pg").PoolClient, done: (release?: any) => void) => void} callback
+ */
 module.exports.getClient = function(callback) {
     if (!pool) {
         return callback(new Error('Connection pool is not open'));
@@ -140,6 +146,9 @@ module.exports.getClient = function(callback) {
     });
 }
 
+/**
+ * @returns {Promise<{client: import("pg").PoolClient, done: (release?: any) => void}>}
+ */
 module.exports.getClientAsync = function(callback) {
     return new Promise((resolve, reject) => {
         module.exports.getClient((err, client, done) => {
@@ -155,6 +164,7 @@ module.exports.getClientAsync = function(callback) {
 /**
  * @param { import("pg").PoolClient } client - The client with which to execute the query
  * @param {String} sql - The SQL query to execute
+ * @param {Params} params
  */
 module.exports.queryWithClient = function(client, sql, params, callback) {
     debug('queryWithClient()', 'sql:', debugString(sql));
@@ -177,13 +187,18 @@ module.exports.queryWithClient = function(client, sql, params, callback) {
 
 module.exports.queryWithClientAsync = promisify(module.exports.queryWithClient);
 
+/**
+ * @param { import("pg").PoolClient } client - The client with which to execute the query
+ * @param {String} sql - The SQL query to execute
+ * @param {Params} params
+ */
 module.exports.queryWithClientOneRow = function(client, sql, params, callback) {
     debug('queryWithClientOneRow()', 'sql:', debugString(sql));
     debug('queryWithClientOneRow()', 'params:', debugParams(params));
     module.exports.queryWithClient(client, sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount !== 1) {
-            var data = {sql: sql, sqlParams: params, result: result};
+            const data = {sql: sql, sqlParams: params, result: result};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('queryWithClientOneRow() success', 'rowCount:', result.rowCount);
@@ -193,13 +208,18 @@ module.exports.queryWithClientOneRow = function(client, sql, params, callback) {
 
 module.exports.queryWithClientOneRowAsync = promisify(module.exports.queryWithClientOneRow);
 
+/**
+ * @param { import("pg").PoolClient } client - The client with which to execute the query
+ * @param {String} sql - The SQL query to execute
+ * @param {Params} params
+ */
 module.exports.queryWithClientZeroOrOneRow = function(client, sql, params, callback) {
     debug('queryWithClientZeroOrOneRow()', 'sql:', debugString(sql));
     debug('queryWithClientZeroOrOneRow()', 'params:', debugParams(params));
-    this.queryWithClient(client, sql, params, function(err, result) {
+    module.exports.queryWithClient(client, sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount > 1) {
-            var data = {sql: sql, sqlParams: params, result: result};
+            const data = {sql: sql, sqlParams: params, result: result};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('queryWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
@@ -207,8 +227,13 @@ module.exports.queryWithClientZeroOrOneRow = function(client, sql, params, callb
     });
 }
 
-module.exports.queryWithClientZeroOrOneRowAsync = promisify(this.queryWithClientZeroOrOneRow);
+module.exports.queryWithClientZeroOrOneRowAsync = promisify(module.exports.queryWithClientZeroOrOneRow);
 
+/**
+ * @param {import("pg").PoolClient} client
+ * @param {(release?: any) => void} done
+ * @param {(err: Error | null) => void} callback
+ */
 module.exports.rollbackWithClient = function(client, done, callback) {
     debug('rollbackWithClient()');
     // from https://github.com/brianc/node-postgres/wiki/Transactions
@@ -226,14 +251,16 @@ module.exports.rollbackWithClient = function(client, done, callback) {
 
 module.exports.rollbackWithClientAsync = promisify(module.exports.rollbackWithClient);
 
+/**
+ * @param {(err: Error | null, client?: import("pg").PoolClient, done?: (release?: any) => void) => void} callback
+ */
 module.exports.beginTransaction = function(callback) {
     debug('beginTransaction()');
-    var that = this;
-    that.getClient(function(err, client, done) {
+    module.exports.getClient(function(err, client, done) {
         if (ERR(err, callback)) return;
-        that.queryWithClient(client, 'START TRANSACTION;', [], function(err) {
+        module.exports.queryWithClient(client, 'START TRANSACTION;', [], function(err) {
             if (err) {
-                that.rollbackWithClient(client, done, function(rollbackErr) {
+                module.exports.rollbackWithClient(client, done, function(rollbackErr) {
                     if (ERR(rollbackErr, callback)) return;
                     return ERR(err, callback);
                 });
@@ -244,7 +271,10 @@ module.exports.beginTransaction = function(callback) {
     });
 }
 
-module.exports.beginTransactionAsync = function() {
+/**
+ * @returns {Promise<{client: import("pg").PoolClient, done: (release?: any) => void}>}
+ */
+module.exports.begiTransactionAsync = function() {
     return new Promise((resolve, reject) => {
         module.exports.beginTransaction((err, client, done) => {
             if (err) {
@@ -256,7 +286,15 @@ module.exports.beginTransactionAsync = function() {
     });
 }
 
-// rollback (if err) or commit the transaction, and release the client
+/**
+ * Commits the transaction if err is null, otherwize rollbacks the transaction.
+ * Also releasese the client.
+ * 
+ * @param { import("pg").PoolClient } client
+ * @param {(rollback?: any) => void} done
+ * @param {Error | null} err
+ * @param {(error: Error | null) => void} callback
+ */
 module.exports.endTransaction = function(client, done, err, callback) {
     debug('endTransaction()');
     if (err) {
@@ -282,6 +320,11 @@ module.exports.endTransaction = function(client, done, err, callback) {
 
 module.exports.endTransactionAsync = promisify(module.exports.endTransaction);
 
+/**
+ * @param {string} sql - The SQL query to execute
+ * @param {Params} params - The params for the query
+ * @param {ResultsCallback} callback
+ */
 module.exports.query = function(sql, params, callback) {
     debug('query()', 'sql:', debugString(sql));
     debug('query()', 'params:', debugParams(params));
@@ -289,7 +332,7 @@ module.exports.query = function(sql, params, callback) {
         return callback(new Error('Connection pool is not open'));
     }
     pool.connect(function(err, client, done) {
-        var handleError = function(err) {
+        const handleError = function(err) {
             if (!err) return false;
             if (client) {
                 done(client);
@@ -316,13 +359,18 @@ module.exports.query = function(sql, params, callback) {
 
 module.exports.queryAsync = promisify(module.exports.query);
 
+/**
+ * @param {string} sql - The SQL query to execute
+ * @param {Params} params - The params for the query
+ * @param {ResultsCallback} callback
+ */
 module.exports.queryOneRow = function(sql, params, callback) {
     debug('queryOneRow()', 'sql:', debugString(sql));
     debug('queryOneRow()', 'params:', debugParams(params));
     module.exports.query(sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount !== 1) {
-            var data = {sql: sql, sqlParams: params};
+            const data = {sql: sql, sqlParams: params};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('queryOneRow() success', 'rowCount:', result.rowCount);
@@ -335,14 +383,15 @@ module.exports.queryOneRowAsync = promisify(module.exports.queryOneRow);
 /**
  * @param {string} sql - The SQL query to execute
  * @param {Params} params - The params for the query
+ * @param {ResultsCallback} callback
  */
 module.exports.queryZeroOrOneRow = function(sql, params, callback) {
     debug('queryZeroOrOneRow()', 'sql:', debugString(sql));
     debug('queryZeroOrOneRow()', 'params:', debugParams(params));
-    this.query(sql, params, function(err, result) {
+    module.exports.query(sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount > 1) {
-            var data = {sql: sql, sqlParams: params};
+            const data = {sql: sql, sqlParams: params};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('queryZeroOrOneRow() success', 'rowCount:', result.rowCount);
@@ -352,12 +401,17 @@ module.exports.queryZeroOrOneRow = function(sql, params, callback) {
 
 module.exports.queryZeroOrOneRowAsync = promisify(module.exports.queryZeroOrOneRow);
 
+/**
+ * @param {string} functionName
+ * @param {Params} params
+ * @param {ResultsCallback} callback
+ */
 module.exports.call = function(functionName, params, callback) {
     debug('call()', 'function:', functionName);
     debug('call()', 'params:', debugParams(params));
-    var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-    var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-    this.query(sql, params, function(err, result) {
+    const placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    const sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    module.exports.query(sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         debug('call() success', 'rowCount:', result.rowCount);
         callback(null, result);
@@ -366,13 +420,18 @@ module.exports.call = function(functionName, params, callback) {
 
 module.exports.callAsync = promisify(module.exports.call);
 
+/**
+ * @param {string} functionName
+ * @param {Params} params
+ * @param {ResultsCallback} callback
+ */
 module.exports.callOneRow = function(functionName, params, callback) {
     debug('callOneRow()', 'function:', functionName);
     debug('callOneRow()', 'params:', debugParams(params));
     module.exports.call(functionName, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount !== 1) {
-            var data = {functionName: functionName, sqlParams: params};
+            const data = {functionName: functionName, sqlParams: params};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('callOneRow() success', 'rowCount:', result.rowCount);
@@ -382,13 +441,18 @@ module.exports.callOneRow = function(functionName, params, callback) {
 
 module.exports.callOneRowAsync = promisify(module.exports.callOneRow);
 
+/**
+ * @param {string} functionName
+ * @param {Params} params
+ * @param {ResultsCallback} callback
+ */
 module.exports.callZeroOrOneRow = function(functionName, params, callback) {
     debug('callZeroOrOneRow()', 'function:', functionName);
     debug('callZeroOrOneRow()', 'params:', debugParams(params));
     module.exports.call(functionName, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount > 1) {
-            var data = {functionName: functionName, sqlParams: params};
+            const data = {functionName: functionName, sqlParams: params};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('callZeroOrOneRow() success', 'rowCount:', result.rowCount);
@@ -398,12 +462,18 @@ module.exports.callZeroOrOneRow = function(functionName, params, callback) {
 
 module.exports.callZeroOrOneRowAsync = promisify(module.exports.callZeroOrOneRow);
 
+/**
+ * @param { import("pg").PoolClient } client
+ * @param {string} functionName
+ * @param {Params} params
+ * @param {ResultsCallback} callback
+ */
 module.exports.callWithClient = function(client, functionName, params, callback) {
     debug('callWithClient()', 'function:', functionName);
     debug('callWithClient()', 'params:', debugParams(params));
-    var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-    var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-    this.queryWithClient(client, sql, params, function(err, result) {
+    const placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    const sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    module.exports.queryWithClient(client, sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         debug('callWithClient() success', 'rowCount:', result.rowCount);
         callback(null, result);
@@ -412,15 +482,21 @@ module.exports.callWithClient = function(client, functionName, params, callback)
 
 module.exports.callWithClientAsync = promisify(module.exports.callWithClient);
 
+/**
+ * @param { import("pg").PoolClient } client
+ * @param {string} functionName
+ * @param {Params} params
+ * @param {ResultsCallback} callback
+ */
 module.exports.callWithClientOneRow = function(client, functionName, params, callback) {
     debug('callWithClientOneRow()', 'function:', functionName);
     debug('callWithClientOneRow()', 'params:', debugParams(params));
-    var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-    var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-    this.queryWithClient(client, sql, params, function(err, result) {
+    const placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    const sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    module.exports.queryWithClient(client, sql, params, function(err, result) {
         if (ERR(err, callback)) return;
         if (result.rowCount !== 1) {
-            var data = {functionName: functionName, sqlParams: params};
+            const data = {functionName: functionName, sqlParams: params};
             return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
         debug('callWithClientOneRow() success', 'rowCount:', result.rowCount);
@@ -430,6 +506,12 @@ module.exports.callWithClientOneRow = function(client, functionName, params, cal
 
 module.exports.callWithClientOneRowAsync = promisify(module.exports.callWithClientOneRow);
 
+/**
+ * @param { import("pg").PoolClient } client
+ * @param {string} functionName
+ * @param {Params} params
+ * @param {ResultsCallback} callback
+ */
 module.exports.callWithClientZeroOrOneRow = function(client, functionName, params, callback) {
     debug('callWithClientZeroOrOneRow()', 'function:', functionName);
     debug('callWithClientZeroOrOneRow()', 'params:', debugParams(params));

--- a/lib/sql-db.js
+++ b/lib/sql-db.js
@@ -1,12 +1,13 @@
-var ERR = require('async-stacktrace');
-var _ = require('lodash');
-var pg = require('pg');
-var path = require('path');
-var debug = require('debug')('prairielib:' + path.basename(__filename, '.js'));
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
+const pg = require('pg');
+const path = require('path');
+const debug = require('debug')('prairielib:' + path.basename(__filename, '.js'));
+const { promisify } = require('util');
 
-var error = require('./error');
+const error = require('./error');
 
-const debugString = function(s) {
+function debugString(s) {
     if (!_.isString(s)) return 'NOT A STRING';
     s = s.replace(/\n/g, '\\n');
     if (s.length > 78) s = s.substring(0, 75) + '...';
@@ -14,7 +15,7 @@ const debugString = function(s) {
     return s;
 };
 
-const debugParams = function(params) {
+function debugParams(params) {
     let s;
     try {
         s = JSON.stringify(params);
@@ -24,360 +25,425 @@ const debugParams = function(params) {
     return debugString(s);
 };
 
-module.exports = {
-    pool: null,
-
-    init: function(pgConfig, idleErrorHandler, callback) {
-        try {
-            this.pool = new pg.Pool(pgConfig);
-        } catch (err) {
-            error.addData(err, {pgConfig: pgConfig});
-            callback(err);
-            return;
-        }
-        this.pool.on('error', function(err, client) {
-            idleErrorHandler(err, client);
-        });
-
-        let retryCount = 0;
-        const retryTimeouts = [500, 1000, 2000, 5000, 10000];
-        const tryConnect = () => {
-            this.pool.connect((err, client, done) => {
-                if (err) {
-                    if (client) {
-                        done(client);
-                    }
-
-                    if (retryCount >= retryTimeouts.length) {
-                        err.message = `Couldn't connect to Postgres after ${retryTimeouts.length} retries: ${err.message}`;
-                        callback(err);
-                        return;
-                    }
-
-                    const timeout = retryTimeouts[retryCount];
-                    retryCount++;
-                    setTimeout(tryConnect, timeout);
-                } else {
-                    done();
-                    callback(null);
-                }
-            });
-        };
-        tryConnect();
-    },
-
-    close: function(callback) {
-        if (!this.pool) {
-            return callback(null);
-        }
-        this.pool.end((err) => {
-            if (ERR(err, callback)) return;
-            this.pool = null;
-            callback(null);
-        });
-    },
-
-    paramsToArray: function(sql, params, callback) {
-        if (!_.isString(sql)) return callback(new Error('SQL must be a string'));
-        if (_.isArray(params)) return callback(null, sql, params);
-        if (!_.isObjectLike(params)) return callback(new Error('params must be array or object'));
-        var re = /\$([-_a-zA-Z0-9]+)/;
-        var result;
-        var processedSql = '';
-        var remainingSql = sql;
-        var nParams = 0;
-        var map = {};
-        var paramsArray = [];
-        while ((result = re.exec(remainingSql)) !== null) {
-            var v = result[1];
-            if (!_(map).has(v)) {
-                if (!_(params).has(v)) return callback(new Error('Missing parameter: ' + v));
-                if (_.isArray(params[v])) {
-                    map[v] = 'ARRAY[' + _.map(_.range(nParams + 1, nParams + params[v].length + 1), function(n) {return '$' + n;}).join(',') + ']';
-                    nParams += params[v].length;
-                    paramsArray = paramsArray.concat(params[v]);
-                } else {
-                    nParams++;
-                    map[v] = '$' + nParams;
-                    paramsArray.push(params[v]);
-                }
+/**
+ * 
+ * @param {String} sql 
+ * @param {Object | Array} params 
+ * @param {*} callback 
+ */
+function paramsToArray(sql, params, callback) {
+    if (!_.isString(sql)) return callback(new Error('SQL must be a string'));
+    if (_.isArray(params)) return callback(null, sql, params);
+    if (!_.isObjectLike(params)) return callback(new Error('params must be array or object'));
+    var re = /\$([-_a-zA-Z0-9]+)/;
+    var result;
+    var processedSql = '';
+    var remainingSql = sql;
+    var nParams = 0;
+    var map = {};
+    var paramsArray = [];
+    while ((result = re.exec(remainingSql)) !== null) {
+        var v = result[1];
+        if (!_(map).has(v)) {
+            if (!_(params).has(v)) return callback(new Error('Missing parameter: ' + v));
+            if (_.isArray(params[v])) {
+                map[v] = 'ARRAY[' + _.map(_.range(nParams + 1, nParams + params[v].length + 1), function(n) {return '$' + n;}).join(',') + ']';
+                nParams += params[v].length;
+                paramsArray = paramsArray.concat(params[v]);
+            } else {
+                nParams++;
+                map[v] = '$' + nParams;
+                paramsArray.push(params[v]);
             }
-            processedSql += remainingSql.substring(0, result.index) + map[v];
-            remainingSql = remainingSql.substring(result.index + result[0].length);
         }
-        processedSql += remainingSql;
-        remainingSql = '';
-        callback(null, processedSql, paramsArray);
-    },
+        processedSql += remainingSql.substring(0, result.index) + map[v];
+        remainingSql = remainingSql.substring(result.index + result[0].length);
+    }
+    processedSql += remainingSql;
+    remainingSql = '';
+    callback(null, processedSql, paramsArray);
+}
 
-    getClient: function(callback) {
-        if (!this.pool) {
-            return callback(new Error('Connection pool is not open'));
-        }
-        this.pool.connect(function(err, client, done) {
+/** @type { import("pg").Pool } */
+let pool = null;
+
+/** @typedef {Object | Array} Params */
+/** @typedef {(result: import("pg")) => void} ResultsCallback */
+
+/**
+ * @param { import("pg").PoolConfig } pgConfig - The config object for Postgres
+ * @param {(error: Error, client: import("pg").PoolClient) => void} idleErrorHandler - A handler for async errors
+ * @param {(error: Error?) => void} callback - Callback once the connection is initialized
+ */
+module.exports.init = function(pgConfig, idleErrorHandler, callback) {
+    try {
+        pool = new pg.Pool(pgConfig);
+    } catch (err) {
+        error.addData(err, {pgConfig: pgConfig});
+        callback(err);
+        return;
+    }
+    pool.on('error', function(err, client) {
+        idleErrorHandler(err, client);
+    });
+
+    let retryCount = 0;
+    const retryTimeouts = [500, 1000, 2000, 5000, 10000];
+    const tryConnect = () => {
+        pool.connect((err, client, done) => {
             if (err) {
                 if (client) {
                     done(client);
                 }
+
+                if (retryCount >= retryTimeouts.length) {
+                    err.message = `Couldn't connect to Postgres after ${retryTimeouts.length} retries: ${err.message}`;
+                    callback(err);
+                    return;
+                }
+
+                const timeout = retryTimeouts[retryCount];
+                retryCount++;
+                setTimeout(tryConnect, timeout);
+            } else {
+                done();
+                callback(null);
+            }
+        });
+    };
+    tryConnect();
+}
+
+module.exports.close = function(callback) {
+    if (!pool) {
+        return callback(null);
+    }
+    pool.end((err) => {
+        if (ERR(err, callback)) return;
+        pool = null;
+        callback(null);
+    });
+}
+
+module.exports.getClient = function(callback) {
+    if (!pool) {
+        return callback(new Error('Connection pool is not open'));
+    }
+    pool.connect(function(err, client, done) {
+        if (err) {
+            if (client) {
+                done(client);
+            }
+            return ERR(err, callback); // unconditionally return
+        }
+        callback(null, client, done);
+    });
+}
+
+module.exports.getClientAsync = function(callback) {
+    return new Promise((resolve, reject) => {
+        module.exports.getClient((err, client, done) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve({ client, done });
+            }
+        });
+    });
+}
+
+/**
+ * @param { import("pg").PoolClient } client - The client with which to execute the query
+ * @param {String} sql - The SQL query to execute
+ */
+module.exports.queryWithClient = function(client, sql, params, callback) {
+    debug('queryWithClient()', 'sql:', debugString(sql));
+    debug('queryWithClient()', 'params:', debugParams(params));
+    paramsToArray(sql, params, function(err, newSql, newParams) {
+        if (err) err = error.addData(err, {sql: sql, sqlParams: params});
+        if (ERR(err, callback)) return;
+        client.query(newSql, newParams, function(err, result) {
+            if (err) {
+                const sqlError = JSON.parse(JSON.stringify(err));
+                sqlError.message = err.message;
+                err = error.addData(err, {sqlError: sqlError, sql: sql, sqlParams: params, result: result});
+            }
+            if (ERR(err, callback)) return;
+            debug('queryWithClient() success', 'rowCount:', result.rowCount);
+            callback(null, result);
+        });
+    });
+}
+
+module.exports.queryWithClientAsync = promisify(module.exports.queryWithClient);
+
+module.exports.queryWithClientOneRow = function(client, sql, params, callback) {
+    debug('queryWithClientOneRow()', 'sql:', debugString(sql));
+    debug('queryWithClientOneRow()', 'params:', debugParams(params));
+    module.exports.queryWithClient(client, sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount !== 1) {
+            var data = {sql: sql, sqlParams: params, result: result};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
+        }
+        debug('queryWithClientOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+};
+
+module.exports.queryWithClientOneRowAsync = promisify(module.exports.queryWithClientOneRow);
+
+module.exports.queryWithClientZeroOrOneRow = function(client, sql, params, callback) {
+    debug('queryWithClientZeroOrOneRow()', 'sql:', debugString(sql));
+    debug('queryWithClientZeroOrOneRow()', 'params:', debugParams(params));
+    this.queryWithClient(client, sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount > 1) {
+            var data = {sql: sql, sqlParams: params, result: result};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
+        }
+        debug('queryWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
+
+module.exports.queryWithClientZeroOrOneRowAsync = promisify(this.queryWithClientZeroOrOneRow);
+
+module.exports.rollbackWithClient = function(client, done, callback) {
+    debug('rollbackWithClient()');
+    // from https://github.com/brianc/node-postgres/wiki/Transactions
+    client.query('ROLLBACK;', function(err) {
+        //if there was a problem rolling back the query
+        //something is seriously messed up.  Return the error
+        //to the done function to close & remove this client from
+        //the pool.  If you leave a client in the pool with an unaborted
+        //transaction weird, hard to diagnose problems might happen.
+        done(err);
+        if (ERR(err, callback)) return;
+        callback(null);
+    });
+};
+
+module.exports.rollbackWithClientAsync = promisify(module.exports.rollbackWithClient);
+
+module.exports.beginTransaction = function(callback) {
+    debug('beginTransaction()');
+    var that = this;
+    that.getClient(function(err, client, done) {
+        if (ERR(err, callback)) return;
+        that.queryWithClient(client, 'START TRANSACTION;', [], function(err) {
+            if (err) {
+                that.rollbackWithClient(client, done, function(rollbackErr) {
+                    if (ERR(rollbackErr, callback)) return;
+                    return ERR(err, callback);
+                });
+            } else {
+                callback(null, client, done);
+            }
+        });
+    });
+}
+
+module.exports.beginTransactionAsync = function() {
+    return new Promise((resolve, reject) => {
+        module.exports.beginTransaction((err, client, done) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve({ client, done });
+            }
+        });
+    });
+}
+
+// rollback (if err) or commit the transaction, and release the client
+module.exports.endTransaction = function(client, done, err, callback) {
+    debug('endTransaction()');
+    if (err) {
+        module.exports.rollbackWithClient(client, done, function(rollbackErr) {
+            if (rollbackErr) {
+                rollbackErr = error.addData(rollbackErr, {prevErr: err, rollback: 'fail'});
+                return ERR(rollbackErr, callback);
+            }
+            err = error.addData(err, {rollback: 'success'});
+            ERR(err, callback);
+        });
+    } else {
+        module.exports.queryWithClient(client, 'COMMIT', [], function(err, _result) {
+            if (err) {
+                done();
                 return ERR(err, callback); // unconditionally return
             }
-            callback(null, client, done);
+            done();
+            callback(null);
         });
-    },
+    }
+}
 
-    queryWithClient: function(client, sql, params, callback) {
-        debug('queryWithClient()', 'sql:', debugString(sql));
-        debug('queryWithClient()', 'params:', debugParams(params));
-        this.paramsToArray(sql, params, function(err, newSql, newParams) {
+module.exports.endTransactionAsync = promisify(module.exports.endTransaction);
+
+module.exports.query = function(sql, params, callback) {
+    debug('query()', 'sql:', debugString(sql));
+    debug('query()', 'params:', debugParams(params));
+    if (!pool) {
+        return callback(new Error('Connection pool is not open'));
+    }
+    pool.connect(function(err, client, done) {
+        var handleError = function(err) {
+            if (!err) return false;
+            if (client) {
+                done(client);
+            }
+            const sqlError = JSON.parse(JSON.stringify(err));
+            sqlError.message = err.message;
+            err = error.addData(err, {sqlError: sqlError, sql: sql, sqlParams: params});
+            ERR(err, callback);
+            return true;
+        };
+        if (handleError(err)) return;
+        paramsToArray(sql, params, function(err, newSql, newParams) {
             if (err) err = error.addData(err, {sql: sql, sqlParams: params});
             if (ERR(err, callback)) return;
             client.query(newSql, newParams, function(err, result) {
-                if (err) {
-                    const sqlError = JSON.parse(JSON.stringify(err));
-                    sqlError.message = err.message;
-                    err = error.addData(err, {sqlError: sqlError, sql: sql, sqlParams: params, result: result});
-                }
-                if (ERR(err, callback)) return;
-                debug('queryWithClient() success', 'rowCount:', result.rowCount);
+                if (handleError(err)) return;
+                done();
+                debug('query() success', 'rowCount:', result.rowCount);
                 callback(null, result);
             });
         });
-    },
+    });
+}
 
-    queryWithClientOneRow: function(client, sql, params, callback) {
-        debug('queryWithClientOneRow()', 'sql:', debugString(sql));
-        debug('queryWithClientOneRow()', 'params:', debugParams(params));
-        this.queryWithClient(client, sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount !== 1) {
-                var data = {sql: sql, sqlParams: params, result: result};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('queryWithClientOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.queryAsync = promisify(module.exports.query);
 
-    queryWithClientZeroOrOneRow: function(client, sql, params, callback) {
-        debug('queryWithClientZeroOrOneRow()', 'sql:', debugString(sql));
-        debug('queryWithClientZeroOrOneRow()', 'params:', debugParams(params));
-        this.queryWithClient(client, sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount > 1) {
-                var data = {sql: sql, sqlParams: params, result: result};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('queryWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
-
-    releaseClient: function(client, done) {
-        debug('releaseClient()');
-        done();
-    },
-
-    rollbackWithClient: function(client, done, callback) {
-        debug('rollbackWithClient()');
-        // from https://github.com/brianc/node-postgres/wiki/Transactions
-        client.query('ROLLBACK;', function(err) {
-            //if there was a problem rolling back the query
-            //something is seriously messed up.  Return the error
-            //to the done function to close & remove this client from
-            //the pool.  If you leave a client in the pool with an unaborted
-            //transaction weird, hard to diagnose problems might happen.
-            done(err);
-            if (ERR(err, callback)) return;
-            callback(null);
-        });
-    },
-
-    // get a client and start a transaction
-    beginTransaction: function(callback) {
-        debug('beginTransaction()');
-        var that = this;
-        that.getClient(function(err, client, done) {
-            if (ERR(err, callback)) return;
-            that.queryWithClient(client, 'START TRANSACTION;', [], function(err) {
-                if (err) {
-                    that.rollbackWithClient(client, done, function(rollbackErr) {
-                        if (ERR(rollbackErr, callback)) return;
-                        return ERR(err, callback);
-                    });
-                } else {
-                    callback(null, client, done);
-                }
-            });
-        });
-    },
-
-    // rollback (if err) or commit the transaction, and release the client
-    endTransaction: function(client, done, err, callback) {
-        debug('endTransaction()');
-        var that = this;
-        if (err) {
-            that.rollbackWithClient(client, done, function(rollbackErr) {
-                if (rollbackErr) {
-                    rollbackErr = error.addData(rollbackErr, {prevErr: err, rollback: 'fail'});
-                    return ERR(rollbackErr, callback);
-                }
-                err = error.addData(err, {rollback: 'success'});
-                ERR(err, callback);
-            });
-        } else {
-            that.queryWithClient(client, 'COMMIT', [], function(err, _result) {
-                if (err) {
-                    done();
-                    return ERR(err, callback); // unconditionally return
-                }
-                done();
-                callback(null);
-            });
+module.exports.queryOneRow = function(sql, params, callback) {
+    debug('queryOneRow()', 'sql:', debugString(sql));
+    debug('queryOneRow()', 'params:', debugParams(params));
+    module.exports.query(sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount !== 1) {
+            var data = {sql: sql, sqlParams: params};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
-    },
+        debug('queryOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
 
-    query: function(sql, params, callback) {
-        debug('query()', 'sql:', debugString(sql));
-        debug('query()', 'params:', debugParams(params));
-        var that = this;
-        if (!this.pool) {
-            return callback(new Error('Connection pool is not open'));
+module.exports.queryOneRowAsync = promisify(module.exports.queryOneRow);
+
+/**
+ * @param {string} sql - The SQL query to execute
+ * @param {Params} params - The params for the query
+ */
+module.exports.queryZeroOrOneRow = function(sql, params, callback) {
+    debug('queryZeroOrOneRow()', 'sql:', debugString(sql));
+    debug('queryZeroOrOneRow()', 'params:', debugParams(params));
+    this.query(sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount > 1) {
+            var data = {sql: sql, sqlParams: params};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
         }
-        that.pool.connect(function(err, client, done) {
-            var handleError = function(err) {
-                if (!err) return false;
-                if (client) {
-                    done(client);
-                }
-                const sqlError = JSON.parse(JSON.stringify(err));
-                sqlError.message = err.message;
-                err = error.addData(err, {sqlError: sqlError, sql: sql, sqlParams: params});
-                ERR(err, callback);
-                return true;
-            };
-            if (handleError(err)) return;
-            that.paramsToArray(sql, params, function(err, newSql, newParams) {
-                if (err) err = error.addData(err, {sql: sql, sqlParams: params});
-                if (ERR(err, callback)) return;
-                client.query(newSql, newParams, function(err, result) {
-                    if (handleError(err)) return;
-                    done();
-                    debug('query() success', 'rowCount:', result.rowCount);
-                    callback(null, result);
-                });
-            });
-        });
-    },
+        debug('queryZeroOrOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
 
-    queryOneRow: function(sql, params, callback) {
-        debug('queryOneRow()', 'sql:', debugString(sql));
-        debug('queryOneRow()', 'params:', debugParams(params));
-        this.query(sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount !== 1) {
-                var data = {sql: sql, sqlParams: params};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('queryOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.queryZeroOrOneRowAsync = promisify(module.exports.queryZeroOrOneRow);
 
-    queryZeroOrOneRow: function(sql, params, callback) {
-        debug('queryZeroOrOneRow()', 'sql:', debugString(sql));
-        debug('queryZeroOrOneRow()', 'params:', debugParams(params));
-        this.query(sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount > 1) {
-                var data = {sql: sql, sqlParams: params};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('queryZeroOrOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.call = function(functionName, params, callback) {
+    debug('call()', 'function:', functionName);
+    debug('call()', 'params:', debugParams(params));
+    var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    this.query(sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        debug('call() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
 
-    call: function(functionName, params, callback) {
-        debug('call()', 'function:', functionName);
-        debug('call()', 'params:', debugParams(params));
-        var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-        var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-        this.query(sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            debug('call() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.callAsync = promisify(module.exports.call);
 
-    callOneRow: function(functionName, params, callback) {
-        debug('callOneRow()', 'function:', functionName);
-        debug('callOneRow()', 'params:', debugParams(params));
-        this.call(functionName, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount !== 1) {
-                var data = {functionName: functionName, sqlParams: params};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('callOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.callOneRow = function(functionName, params, callback) {
+    debug('callOneRow()', 'function:', functionName);
+    debug('callOneRow()', 'params:', debugParams(params));
+    module.exports.call(functionName, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount !== 1) {
+            var data = {functionName: functionName, sqlParams: params};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
+        }
+        debug('callOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
 
-    callZeroOrOneRow: function(functionName, params, callback) {
-        debug('callZeroOrOneRow()', 'function:', functionName);
-        debug('callZeroOrOneRow()', 'params:', debugParams(params));
-        this.call(functionName, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount > 1) {
-                var data = {functionName: functionName, sqlParams: params};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('callZeroOrOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.callOneRowAsync = promisify(module.exports.callOneRow);
 
-    callWithClient: function(client, functionName, params, callback) {
-        debug('callWithClient()', 'function:', functionName);
-        debug('callWithClient()', 'params:', debugParams(params));
-        var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-        var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-        this.queryWithClient(client, sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            debug('callWithClient() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.callZeroOrOneRow = function(functionName, params, callback) {
+    debug('callZeroOrOneRow()', 'function:', functionName);
+    debug('callZeroOrOneRow()', 'params:', debugParams(params));
+    module.exports.call(functionName, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount > 1) {
+            var data = {functionName: functionName, sqlParams: params};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
+        }
+        debug('callZeroOrOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
 
-    callWithClientOneRow: function(client, functionName, params, callback) {
-        debug('callWithClientOneRow()', 'function:', functionName);
-        debug('callWithClientOneRow()', 'params:', debugParams(params));
-        var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-        var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-        this.queryWithClient(client, sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount !== 1) {
-                var data = {functionName: functionName, sqlParams: params};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('callWithClientOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
+module.exports.callZeroOrOneRowAsync = promisify(module.exports.callZeroOrOneRow);
 
-    callWithClientZeroOrOneRow: function(client, functionName, params, callback) {
-        debug('callWithClientZeroOrOneRow()', 'function:', functionName);
-        debug('callWithClientZeroOrOneRow()', 'params:', debugParams(params));
-        var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
-        var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
-        this.queryWithClient(client, sql, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount > 1) {
-                var data = {functionName: functionName, sqlParams: params};
-                return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
-            }
-            debug('callWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
-            callback(null, result);
-        });
-    },
-};
+module.exports.callWithClient = function(client, functionName, params, callback) {
+    debug('callWithClient()', 'function:', functionName);
+    debug('callWithClient()', 'params:', debugParams(params));
+    var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    this.queryWithClient(client, sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        debug('callWithClient() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
+
+module.exports.callWithClientAsync = promisify(module.exports.callWithClient);
+
+module.exports.callWithClientOneRow = function(client, functionName, params, callback) {
+    debug('callWithClientOneRow()', 'function:', functionName);
+    debug('callWithClientOneRow()', 'params:', debugParams(params));
+    var placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    var sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    this.queryWithClient(client, sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount !== 1) {
+            var data = {functionName: functionName, sqlParams: params};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
+        }
+        debug('callWithClientOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
+
+module.exports.callWithClientOneRowAsync = promisify(module.exports.callWithClientOneRow);
+
+module.exports.callWithClientZeroOrOneRow = function(client, functionName, params, callback) {
+    debug('callWithClientZeroOrOneRow()', 'function:', functionName);
+    debug('callWithClientZeroOrOneRow()', 'params:', debugParams(params));
+    const placeholders = _.map(_.range(1, params.length + 1), v => '$' + v).join();
+    const sql = 'SELECT * FROM ' + functionName + '(' + placeholders + ')';
+    module.exports.queryWithClient(client, sql, params, function(err, result) {
+        if (ERR(err, callback)) return;
+        if (result.rowCount > 1) {
+            const data = {functionName: functionName, sqlParams: params};
+            return callback(error.makeWithData('Incorrect rowCount: ' + result.rowCount, data));
+        }
+        debug('callWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
+        callback(null, result);
+    });
+}
+
+module.exports.callWithClientZeroOrOneRowAsync = promisify(module.exports.callWithClientZeroOrOneRow);

--- a/lib/sql-db.js
+++ b/lib/sql-db.js
@@ -134,7 +134,12 @@ module.exports.init = function(pgConfig, idleErrorHandler, callback) {
 }
 
 /**
- * Closes the connection pool
+ * Creates a new connection pool and attempts to connect to the database.
+ */
+module.exports.initAsync = promisify(module.exports.init);
+
+/**
+ * Closes the connection pool.
  * 
  * @param {(error: Error | null) => void} callback
  */
@@ -148,6 +153,11 @@ module.exports.close = function(callback) {
         callback(null);
     });
 }
+
+/**
+ * Closes the connection pool.
+ */
+module.exports.closeAsync = promisify(module.exports.close);
 
 /**
  * Gets a new client from the connection pool.

--- a/lib/sql-db.js
+++ b/lib/sql-db.js
@@ -7,6 +7,12 @@ const { promisify } = require('util');
 
 const error = require('./error');
 
+/**
+ * Formats a string for debugging.
+ * 
+ * @param {string} s
+ * @returns string
+ */
 function debugString(s) {
     if (!_.isString(s)) return 'NOT A STRING';
     s = s.replace(/\n/g, '\\n');
@@ -15,6 +21,12 @@ function debugString(s) {
     return s;
 };
 
+/**
+ * Formats a set of params for debugging.
+ * 
+ * @param {Params} params 
+ * @returns string
+ */
 function debugParams(params) {
     let s;
     try {
@@ -26,10 +38,12 @@ function debugParams(params) {
 };
 
 /**
+ * Given an SQL string and params, creates an array of params and an SQL string
+ * with any named dollar-sign placeholders replaced with parameters.
  * 
  * @param {String} sql 
- * @param {Object | Array} params 
- * @param {*} callback 
+ * @param {Params} params 
+ * @param {(error: Error | null, processedSql: string, paramsArray: any[])} callback 
  */
 function paramsToArray(sql, params, callback) {
     if (!_.isString(sql)) return callback(new Error('SQL must be a string'));
@@ -64,13 +78,18 @@ function paramsToArray(sql, params, callback) {
     callback(null, processedSql, paramsArray);
 }
 
-/** @type { import("pg").Pool } */
+/**
+ * The pool from which clients will be acquired.
+ * @type { import("pg").Pool }
+ */
 let pool = null;
 
-/** @typedef {Object | Array} Params */
+/** @typedef {{[key: string]: any} | any[]} Params */
 /** @typedef {(error: Error | null, result: import("pg").QueryResult) => void} ResultsCallback */
 
 /**
+ * Creates a new connection pool and attempts to connect to the database.
+ * 
  * @param { import("pg").PoolConfig } pgConfig - The config object for Postgres
  * @param {(error: Error, client: import("pg").PoolClient) => void} idleErrorHandler - A handler for async errors
  * @param {(error: Error | null) => void} callback - Callback once the connection is initialized
@@ -115,6 +134,8 @@ module.exports.init = function(pgConfig, idleErrorHandler, callback) {
 }
 
 /**
+ * Closes the connection pool
+ * 
  * @param {(error: Error | null) => void} callback
  */
 module.exports.close = function(callback) {
@@ -129,6 +150,8 @@ module.exports.close = function(callback) {
 }
 
 /**
+ * Gets a new client from the connection pool.
+ * 
  * @param {(error: Error | null, client: import("pg").PoolClient, done: (release?: any) => void) => void} callback
  */
 module.exports.getClient = function(callback) {
@@ -147,6 +170,8 @@ module.exports.getClient = function(callback) {
 }
 
 /**
+ * Gets a new client from the connection pool.
+ * 
  * @returns {Promise<{client: import("pg").PoolClient, done: (release?: any) => void}>}
  */
 module.exports.getClientAsync = function(callback) {
@@ -162,6 +187,8 @@ module.exports.getClientAsync = function(callback) {
 }
 
 /**
+ * Performs a query with the given client.
+ * 
  * @param { import("pg").PoolClient } client - The client with which to execute the query
  * @param {String} sql - The SQL query to execute
  * @param {Params} params
@@ -185,12 +212,19 @@ module.exports.queryWithClient = function(client, sql, params, callback) {
     });
 }
 
+/**
+ * Performs a query with the given client.
+ */
 module.exports.queryWithClientAsync = promisify(module.exports.queryWithClient);
 
 /**
+ * Performs a query with the given client. Errors if the query returns more
+ * than one row.
+ * 
  * @param { import("pg").PoolClient } client - The client with which to execute the query
  * @param {String} sql - The SQL query to execute
  * @param {Params} params
+ * @param {ResultsCallback} callback
  */
 module.exports.queryWithClientOneRow = function(client, sql, params, callback) {
     debug('queryWithClientOneRow()', 'sql:', debugString(sql));
@@ -206,9 +240,15 @@ module.exports.queryWithClientOneRow = function(client, sql, params, callback) {
     });
 };
 
+/**
+ * Performs a query with the given client. Errors if the query returns more
+ * than one row.
+ */
 module.exports.queryWithClientOneRowAsync = promisify(module.exports.queryWithClientOneRow);
 
 /**
+ * Performs a query with the given client. Errors if the query returns more
+ * than one row.
  * @param { import("pg").PoolClient } client - The client with which to execute the query
  * @param {String} sql - The SQL query to execute
  * @param {Params} params
@@ -227,9 +267,15 @@ module.exports.queryWithClientZeroOrOneRow = function(client, sql, params, callb
     });
 }
 
+/**
+ * Performs a query with the given client. Errors if the query returns more
+ * than one row.
+ */
 module.exports.queryWithClientZeroOrOneRowAsync = promisify(module.exports.queryWithClientZeroOrOneRow);
 
 /**
+ * Rolls back the current transaction for the given client.
+ * 
  * @param {import("pg").PoolClient} client
  * @param {(release?: any) => void} done
  * @param {(err: Error | null) => void} callback
@@ -249,9 +295,14 @@ module.exports.rollbackWithClient = function(client, done, callback) {
     });
 };
 
+/**
+ * Rolls back the current transaction for the given client.
+ */
 module.exports.rollbackWithClientAsync = promisify(module.exports.rollbackWithClient);
 
 /**
+ * Begins a new transaction.
+ * 
  * @param {(err: Error | null, client?: import("pg").PoolClient, done?: (release?: any) => void) => void} callback
  */
 module.exports.beginTransaction = function(callback) {
@@ -272,6 +323,8 @@ module.exports.beginTransaction = function(callback) {
 }
 
 /**
+ * Begins a new transation.
+ * 
  * @returns {Promise<{client: import("pg").PoolClient, done: (release?: any) => void}>}
  */
 module.exports.begiTransactionAsync = function() {
@@ -318,9 +371,15 @@ module.exports.endTransaction = function(client, done, err, callback) {
     }
 }
 
+/**
+ * Commits the transaction if err is null, otherwize rollbacks the transaction.
+ * Also releasese the client.
+ */
 module.exports.endTransactionAsync = promisify(module.exports.endTransaction);
 
 /**
+ * Executes a query with the specified parameters.
+ * 
  * @param {string} sql - The SQL query to execute
  * @param {Params} params - The params for the query
  * @param {ResultsCallback} callback
@@ -357,9 +416,15 @@ module.exports.query = function(sql, params, callback) {
     });
 }
 
+/**
+ * Executes a query with the specified parameters.
+ */
 module.exports.queryAsync = promisify(module.exports.query);
 
 /**
+ * Executes a query with the specified parameters. Errors if the query does
+ * not return exactly one row.
+ * 
  * @param {string} sql - The SQL query to execute
  * @param {Params} params - The params for the query
  * @param {ResultsCallback} callback
@@ -378,9 +443,16 @@ module.exports.queryOneRow = function(sql, params, callback) {
     });
 }
 
+/**
+ * Executes a query with the specified parameters. Errors if the query does
+ * not return exactly one row.
+ */
 module.exports.queryOneRowAsync = promisify(module.exports.queryOneRow);
 
 /**
+ * Executes a query with the specified parameters. Errors if the query
+ * returns more than one row.
+ * 
  * @param {string} sql - The SQL query to execute
  * @param {Params} params - The params for the query
  * @param {ResultsCallback} callback
@@ -399,11 +471,17 @@ module.exports.queryZeroOrOneRow = function(sql, params, callback) {
     });
 }
 
+/**
+ * Executes a query with the specified parameters. Errors if the query
+ * returns more than one row.
+ */
 module.exports.queryZeroOrOneRowAsync = promisify(module.exports.queryZeroOrOneRow);
 
 /**
- * @param {string} functionName
- * @param {Params} params
+ * Calls the given function with the specified parameters.
+ * 
+ * @param {string} functionName - The name of the function to call
+ * @param {any[]} params - The params for the function
  * @param {ResultsCallback} callback
  */
 module.exports.call = function(functionName, params, callback) {
@@ -418,11 +496,17 @@ module.exports.call = function(functionName, params, callback) {
     });
 }
 
+/**
+ * Calls the given function with the specified parameters.
+ */
 module.exports.callAsync = promisify(module.exports.call);
 
 /**
- * @param {string} functionName
- * @param {Params} params
+ * Calls the given function with the specified parameters. Errors if the
+ * function does not return exactly one row.
+ * 
+ * @param {string} functionName - The name of the function to call
+ * @param {Params} params - The params for the function
  * @param {ResultsCallback} callback
  */
 module.exports.callOneRow = function(functionName, params, callback) {
@@ -439,11 +523,18 @@ module.exports.callOneRow = function(functionName, params, callback) {
     });
 }
 
+/**
+ * Calls the given function with the specified parameters. Errors if the
+ * function does not return exactly one row.
+ */
 module.exports.callOneRowAsync = promisify(module.exports.callOneRow);
 
 /**
- * @param {string} functionName
- * @param {Params} params
+ * Calls the given function with the specified parameters. Errors if the
+ * function returns more than one row.
+ * 
+ * @param {string} functionName - The name of the function to call
+ * @param {Params} params - The params for the function
  * @param {ResultsCallback} callback
  */
 module.exports.callZeroOrOneRow = function(functionName, params, callback) {
@@ -460,9 +551,15 @@ module.exports.callZeroOrOneRow = function(functionName, params, callback) {
     });
 }
 
+/**
+ * Calls the given function with the specified parameters. Errors if the
+ * function returns more than one row.
+ */
 module.exports.callZeroOrOneRowAsync = promisify(module.exports.callZeroOrOneRow);
 
 /**
+ * Calls a function with the specified parameters using a specific client.
+ * 
  * @param { import("pg").PoolClient } client
  * @param {string} functionName
  * @param {Params} params
@@ -480,9 +577,15 @@ module.exports.callWithClient = function(client, functionName, params, callback)
     });
 }
 
+/**
+ * Calls a function with the specified parameters using a specific client.
+ */
 module.exports.callWithClientAsync = promisify(module.exports.callWithClient);
 
 /**
+ * Calls a function with the specified parameters using a specific client.
+ * Errors if the function does not return exactly one row.
+ * 
  * @param { import("pg").PoolClient } client
  * @param {string} functionName
  * @param {Params} params
@@ -504,9 +607,16 @@ module.exports.callWithClientOneRow = function(client, functionName, params, cal
     });
 }
 
+/**
+ * Calls a function with the specified parameters using a specific client.
+ * Errors if the function does not return exactly one row.
+ */
 module.exports.callWithClientOneRowAsync = promisify(module.exports.callWithClientOneRow);
 
 /**
+ * Calls a function with the specified parameters using a specific client.
+ * Errors if the function returns more than one row.
+ * 
  * @param { import("pg").PoolClient } client
  * @param {string} functionName
  * @param {Params} params
@@ -528,4 +638,8 @@ module.exports.callWithClientZeroOrOneRow = function(client, functionName, param
     });
 }
 
+/**
+ * Calls a function with the specified parameters using a specific client.
+ * Errors if the function returns more than one row.
+ */
 module.exports.callWithClientZeroOrOneRowAsync = promisify(module.exports.callWithClientZeroOrOneRow);

--- a/lib/sql-db.js
+++ b/lib/sql-db.js
@@ -19,7 +19,7 @@ function debugString(s) {
     if (s.length > 78) s = s.substring(0, 75) + '...';
     s = '"' + s + '"';
     return s;
-};
+}
 
 /**
  * Formats a set of params for debugging.
@@ -35,7 +35,7 @@ function debugParams(params) {
         s = 'CANNOT JSON STRINGIFY';
     }
     return debugString(s);
-};
+}
 
 /**
  * Given an SQL string and params, creates an array of params and an SQL string
@@ -131,7 +131,7 @@ module.exports.init = function(pgConfig, idleErrorHandler, callback) {
         });
     };
     tryConnect();
-}
+};
 
 /**
  * Creates a new connection pool and attempts to connect to the database.
@@ -152,7 +152,7 @@ module.exports.close = function(callback) {
         pool = null;
         callback(null);
     });
-}
+};
 
 /**
  * Closes the connection pool.
@@ -177,14 +177,14 @@ module.exports.getClient = function(callback) {
         }
         callback(null, client, done);
     });
-}
+};
 
 /**
  * Gets a new client from the connection pool.
  * 
  * @returns {Promise<{client: import("pg").PoolClient, done: (release?: any) => void}>}
  */
-module.exports.getClientAsync = function(callback) {
+module.exports.getClientAsync = function() {
     return new Promise((resolve, reject) => {
         module.exports.getClient((err, client, done) => {
             if (err) {
@@ -194,7 +194,7 @@ module.exports.getClientAsync = function(callback) {
             }
         });
     });
-}
+};
 
 /**
  * Performs a query with the given client.
@@ -220,7 +220,7 @@ module.exports.queryWithClient = function(client, sql, params, callback) {
             callback(null, result);
         });
     });
-}
+};
 
 /**
  * Performs a query with the given client.
@@ -275,7 +275,7 @@ module.exports.queryWithClientZeroOrOneRow = function(client, sql, params, callb
         debug('queryWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Performs a query with the given client. Errors if the query returns more
@@ -330,7 +330,7 @@ module.exports.beginTransaction = function(callback) {
             }
         });
     });
-}
+};
 
 /**
  * Begins a new transation.
@@ -347,7 +347,7 @@ module.exports.begiTransactionAsync = function() {
             }
         });
     });
-}
+};
 
 /**
  * Commits the transaction if err is null, otherwize rollbacks the transaction.
@@ -379,7 +379,7 @@ module.exports.endTransaction = function(client, done, err, callback) {
             callback(null);
         });
     }
-}
+};
 
 /**
  * Commits the transaction if err is null, otherwize rollbacks the transaction.
@@ -424,7 +424,7 @@ module.exports.query = function(sql, params, callback) {
             });
         });
     });
-}
+};
 
 /**
  * Executes a query with the specified parameters.
@@ -451,7 +451,7 @@ module.exports.queryOneRow = function(sql, params, callback) {
         debug('queryOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Executes a query with the specified parameters. Errors if the query does
@@ -479,7 +479,7 @@ module.exports.queryZeroOrOneRow = function(sql, params, callback) {
         debug('queryZeroOrOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Executes a query with the specified parameters. Errors if the query
@@ -504,7 +504,7 @@ module.exports.call = function(functionName, params, callback) {
         debug('call() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Calls the given function with the specified parameters.
@@ -531,7 +531,7 @@ module.exports.callOneRow = function(functionName, params, callback) {
         debug('callOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Calls the given function with the specified parameters. Errors if the
@@ -559,7 +559,7 @@ module.exports.callZeroOrOneRow = function(functionName, params, callback) {
         debug('callZeroOrOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Calls the given function with the specified parameters. Errors if the
@@ -585,7 +585,7 @@ module.exports.callWithClient = function(client, functionName, params, callback)
         debug('callWithClient() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Calls a function with the specified parameters using a specific client.
@@ -615,7 +615,7 @@ module.exports.callWithClientOneRow = function(client, functionName, params, cal
         debug('callWithClientOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Calls a function with the specified parameters using a specific client.
@@ -646,7 +646,7 @@ module.exports.callWithClientZeroOrOneRow = function(client, functionName, param
         debug('callWithClientZeroOrOneRow() success', 'rowCount:', result.rowCount);
         callback(null, result);
     });
-}
+};
 
 /**
  * Calls a function with the specified parameters using a specific client.


### PR DESCRIPTION
In my syncing improvement work in PrairieLearn, I'm trying to leverage async/await as much as possible to make things more readable. I was inlining async wrappers to the db in each file I used them, but that's obviously not a good long-term solution. This PR adds async (Promise-based) versions of all database functions, making liberal use of `util.promisify` where possible to reduce code duplication.

I also did my best to add JSDoc types and docs to everything so that editors like VSCode can pick up on them for code completion. If we ever decide to move to TypeScript, it'll be easy to switch to first-class types.